### PR TITLE
bash script for running daily SCL tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: run_daily_tests
+
+run_daily_tests:
+	bash daily_tests/daily_scl_tests.sh

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # ci-scripts
 Set of generic scripts that are run in the CI (Jenkins or any other)
+
+## daily_tests
+
+The directory contains a script for running SCL
+tests which are executed periodically each day.
+
+The aim of this script is to avoid the situation
+if an upstream, like `gunicorn` updates PyPi
+version and our python container tests are failing.

--- a/daily_tests/daily_scl_tests.sh
+++ b/daily_tests/daily_scl_tests.sh
@@ -1,12 +1,21 @@
 #!/bin/bash
 
-SCL_CONTAINERS="s2i-php-container \
+SCL_CONTAINERS="s2i-nodejs-container \
+s2i-base-container \
+s2i-php-container \
 s2i-perl-container \
 s2i-ruby-container \
 s2i-python-container \
-container-common-scripts \
-s2i-nodejs-container \
-s2i-base-container"
+postgresql-container \
+varnish-container \
+nginx-container \
+httpd-container \
+mariadb-container \
+redis-container \
+mysql-container \
+mongodb-container \
+golang-container
+"
 
 TMP_DIR="/tmp/daily_scl_tests"
 RESULT_DIR="${TMP_DIR}/results"
@@ -21,6 +30,7 @@ function clone_repo() {
     git clone "https://github.com/sclorg/${repo_name}.git"
     cd ${repo_name}
     git submodule update --init
+    git submodule update --remote
 }
 
 function iterate_over_all_containers() {
@@ -28,10 +38,7 @@ function iterate_over_all_containers() {
         cd ${TMP_DIR}
         local log_name="${TMP_DIR}/${repo}.log"
         clone_repo "$repo"
-        make test CUSTOM_REPO=/vagrant/repos7 TARGET=rhel7 > "${log_name}" 2>&1
-        if [[ $? -ne 0 ]]; then
-            cp "${log_name}" "${RESULT_DIR}/"
-        fi
+        make test TARGET=centos7 > "${log_name}" 2>&1 || cp "${log_name}" "${RESULT_DIR}/"
     done
 }
 

--- a/daily_tests/daily_scl_tests.sh
+++ b/daily_tests/daily_scl_tests.sh
@@ -21,24 +21,23 @@ TMP_DIR="/tmp/daily_scl_tests"
 RESULT_DIR="${TMP_DIR}/results"
 
 if [[ -d "${TMP_DIR}" ]]; then
-    rm -rf "${TMP_DIR}/"
+    rm -rf "${TMP_DIR:?}/"
 fi
 mkdir -p "${RESULT_DIR}"
 
 function clone_repo() {
     local repo_name=$1; shift
     git clone "https://github.com/sclorg/${repo_name}.git"
-    cd ${repo_name}
+    cd "${repo_name}" || { echo "Repository ${repo_name} does not exist. Skipping." && return 1 ; }
     git submodule update --init
     git submodule update --remote
 }
 
 function iterate_over_all_containers() {
     for repo in ${SCL_CONTAINERS}; do
-        cd ${TMP_DIR}
+        cd ${TMP_DIR} || exit
         local log_name="${TMP_DIR}/${repo}.log"
-        clone_repo "$repo"
-        make test TARGET=centos7 > "${log_name}" 2>&1 || cp "${log_name}" "${RESULT_DIR}/"
+        clone_repo "$repo" && make test TARGET=centos7 > "${log_name}" 2>&1 || cp "${log_name}" "${RESULT_DIR}/"
     done
 }
 

--- a/daily_tests/daily_scl_tests.sh
+++ b/daily_tests/daily_scl_tests.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+SCL_CONTAINERS="s2i-php-container \
+s2i-perl-container \
+s2i-ruby-container \
+s2i-python-container \
+container-common-scripts \
+s2i-nodejs-container \
+s2i-base-container"
+
+TMP_DIR="/tmp/daily_scl_tests"
+RESULT_DIR="${TMP_DIR}/results"
+
+if [[ -d "${TMP_DIR}" ]]; then
+    rm -rf "${TMP_DIR}/"
+fi
+mkdir -p "${RESULT_DIR}"
+
+function clone_repo() {
+    local repo_name=$1; shift
+    git clone "https://github.com/sclorg/${repo_name}.git"
+    cd ${repo_name}
+    git submodule update --init
+}
+
+function iterate_over_all_containers() {
+    for repo in ${SCL_CONTAINERS}; do
+        cd ${TMP_DIR}
+        local log_name="${TMP_DIR}/${repo}.log"
+        clone_repo "$repo"
+        make test CUSTOM_REPO=/vagrant/repos7 TARGET=rhel7 > "${log_name}" 2>&1
+        if [[ $? -ne 0 ]]; then
+            cp "${log_name}" "${RESULT_DIR}/"
+        fi
+    done
+}
+
+iterate_over_all_containers


### PR DESCRIPTION
This pull request adds script for running daily SCL tests
We want to avoid situation if something fails because of
a PyPi, NodeJS modules are not supported. Like in gunicorn
case.
Failed tests are stored into `/tmp/daily_scl_tests/results`
directory with the name `<upstream-git-name>`.log file.

Also README.md is updated with couple description notes.

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>