### PR TITLE
In case of container failure move failed log

### DIFF
--- a/daily_tests/daily_scl_tests.sh
+++ b/daily_tests/daily_scl_tests.sh
@@ -37,7 +37,7 @@ function iterate_over_all_containers() {
     for repo in ${SCL_CONTAINERS}; do
         cd ${TMP_DIR} || exit
         local log_name="${TMP_DIR}/${repo}.log"
-        clone_repo "$repo" && make test TARGET=centos7 > "${log_name}" 2>&1 || cp "${log_name}" "${RESULT_DIR}/"
+        clone_repo "$repo" && make test TARGET=centos7 > "${log_name}" 2>&1 || mv "${log_name}" "${RESULT_DIR}/"
     done
 }
 


### PR DESCRIPTION
Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>

Do not duplicate logs. In case of failure mv failed log into results directory