### PR TITLE
Change order of building container.

### DIFF
--- a/daily_tests/daily_scl_tests.sh
+++ b/daily_tests/daily_scl_tests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-SCL_CONTAINERS="s2i-nodejs-container \
-s2i-base-container \
+SCL_CONTAINERS="s2i-base-container \
+s2i-nodejs-container \
 s2i-php-container \
 s2i-perl-container \
 s2i-ruby-container \


### PR DESCRIPTION
First, build s2i-base-container.
The rest containers will use the latest
base and core container image during testing nightly build.

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>