### PR TITLE
Append filename as string into failed_containers array

### DIFF
--- a/send_results.py
+++ b/send_results.py
@@ -76,7 +76,7 @@ class SendResults:
             )
             self.msg.attach(file_attachment)
             # Delete log file and append into failed_containers array
-            failed_containers.append(filename)
+            failed_containers.append(str(filename))
             filename.unlink()
         return failed_containers
 


### PR DESCRIPTION
This commit contains fix for traceback:
```python
10:08:24 Traceback (most recent call last):
10:08:24   File "./send_results.py", line 108, in <module>
10:08:24     sr.send_results()
10:08:24   File "./send_results.py", line 93, in send_results
10:08:24     cont="<br>Failed containers: " + " ".join(failed_containers),
10:08:24 TypeError: sequence item 0: expected str instance, PosixPath found
```

failed_container is a field of string and not Path.
Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>
