### PR TITLE
Report in case of repository was not clonned

### DIFF
--- a/daily_tests/daily_scl_tests.sh
+++ b/daily_tests/daily_scl_tests.sh
@@ -34,7 +34,7 @@ function clone_repo() {
     # Sometimes clonning failed with an error
     # The requested URL returned error: 500. Save it into log for info
     git clone "https://github.com/sclorg/${repo_name}.git" || \
-        { echo "Repository ${repo_name} was not clonned." > ${RESULT_DIR}/${repo_name}.log && return 1 ; }
+        { echo "Repository ${repo_name} was not clonned." > ${RESULT_DIR}/${repo_name}.log; return 1 ; }
     cd "${repo_name}" || { echo "Repository ${repo_name} does not exist. Skipping." && return 1 ; }
     git submodule update --init
     git submodule update --remote

--- a/daily_tests/daily_scl_tests.sh
+++ b/daily_tests/daily_scl_tests.sh
@@ -31,7 +31,10 @@ mkdir -p "${RESULT_DIR}"
 
 function clone_repo() {
     local repo_name=$1; shift
-    git clone "https://github.com/sclorg/${repo_name}.git"
+    # Sometimes clonning failed with an error
+    # The requested URL returned error: 500. Save it into log for info
+    git clone "https://github.com/sclorg/${repo_name}.git" || \
+        { echo "Repository ${repo_name} was not clonned." > ${RESULT_DIR}/${repo_name}.log && return 1 ; }
     cd "${repo_name}" || { echo "Repository ${repo_name} does not exist. Skipping." && return 1 ; }
     git submodule update --init
     git submodule update --remote


### PR DESCRIPTION
Sometimes on rhel8 repository is not clonned.
Report it into the log file so we have information
that somethings going wrong.

E.g. error message from RHEL8 nightly builds.
```bash
Cloning into 's2i-perl-container'...
remote: Internal Server Error.
remote: 
fatal: unable to access 'https://github.com/sclorg/s2i-perl-container.git/': The requested URL returned error: 500
Repository s2i-perl-container does not exist. Skipping.
```
Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>