### PR TITLE
Call scripts from source directory

### DIFF
--- a/jenkins_ci/commit-into-generated-branch.sh
+++ b/jenkins_ci/commit-into-generated-branch.sh
@@ -6,7 +6,7 @@ set -ex
 
 git config --global user.name "SCLorg Jenkins"
 git config --global user.email "sclorg@redhat.com"
-cd sources
+
 if git ls-remote --exit-code origin generated &>/dev/null; then
   ./common/update-generated.sh
   git diff origin/generated..generated

--- a/jenkins_ci/prepare-centos.sh
+++ b/jenkins_ci/prepare-centos.sh
@@ -37,4 +37,4 @@ git clone https://github.com/sclorg/ci-scripts.git $(pwd)/ci-scripts
 rsync -azP -e 'ssh -F ssh_config' $(pwd)/ host:sources
 ssh -F ssh_config host 'cd sources && git submodule update --init'
 # prepare CentOS machine for working with docker
-ssh -F ssh_config host 'ci-scripts/jenkins_ci/prepare-centos-docker.sh'
+ssh -F ssh_config host 'cd sources && ./ci-scripts/jenkins_ci/prepare-centos-docker.sh'

--- a/jenkins_ci/run-tests.sh
+++ b/jenkins_ci/run-tests.sh
@@ -5,7 +5,6 @@
 set -ex
 
 TARGET_OS=$1
-cd sources
 
 function run_conu() {
     if [ -f ./test/run-conu ]; then


### PR DESCRIPTION
Before calling each script Jenkins Job has to switch into the sources directory.

Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>