### PR TITLE
Add script to update Quay image description

### DIFF
--- a/jenkins_ci/update_quay_description.py
+++ b/jenkins_ci/update_quay_description.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+
+# This script updates Quay image description
+
+import os
+import sys
+import re
+import requests
+from typing import Optional, List
+
+
+token = os.environ["REGISTRY_TOKEN"] # Quay token
+image_name = os.environ["IMAGE_NAME"] # Quay image name
+registry_namespace = os.environ["REGISTRY_NAMESPACE"] # Quay namespace
+context = os.environ["DOCKER_CONTEXT"] # Build Context
+github_repo = os.environ["GITHUB_REPO"] # Name of repo on github
+suffix = ""
+if "SUFFIX" in os.environ:
+    suffix = f"-{os.environ['SUFFIX']}"
+
+
+def print_api_error(status_code: int) -> None:
+    errors = {400: "Bad Request",
+              401: "Session required",
+              403: "Unauthorized access",
+              404: "Not found"}
+    if status_code not in errors.keys():
+        print("Unknown API error")
+    else:
+        print(errors[status_code])
+
+
+def load_readme_as_list(dir: str) -> Optional[List[str]]:
+    readme_path = os.path.join(dir, "README.md")
+    with open(readme_path) as readme:
+        lines = readme.readlines()
+        for i, line in enumerate(lines):
+            if re.match("Description", line):
+                if i + 3 >= len(lines):
+                    break
+                return lines[i + 3:]
+    return None
+
+
+def update_description(readme: str) -> int:
+    api_request_path = f"https://quay.io/api/v1/repository/{registry_namespace}/{image_name}{suffix}"
+    print(api_request_path)
+    headers = {"Content-Type": "application/json",
+               "Authorization": f"Bearer {token}"}
+    data = {"description": readme}
+    r = requests.put(api_request_path, headers=headers, json=data)
+    return r.status_code
+
+
+if __name__ == "__main__":
+    if registry_namespace != "sclorg" and registry_namespace != "centos7":
+        print("Invalid namespace. This script supports only sclorg and centos7 namespaces")
+        sys.exit(1)
+
+    readme_as_list = load_readme_as_list(context)
+    if readme_as_list is None:
+        print("Invalid README format")
+        sys.exit(1)
+    if len(readme_as_list) > 100:
+        readme_as_list = readme_as_list[:98]
+        readme_as_list.append("```\n<br>\n")
+        readme_as_list.append(f"Learn more at <https://github.com/sclorg/{github_repo}/{context}/README.md>")
+    
+    readme = "".join(readme_as_list)
+    request_status = update_description(readme)
+    if request_status != 200:
+        print_api_error(request_status)
+        sys.exit(1)

--- a/jenkins_ci/update_quay_description.py
+++ b/jenkins_ci/update_quay_description.py
@@ -9,16 +9,6 @@ import requests
 from typing import Optional, List
 
 
-token = os.environ["REGISTRY_TOKEN"] # Quay token
-image_name = os.environ["IMAGE_NAME"] # Quay image name
-registry_namespace = os.environ["REGISTRY_NAMESPACE"] # Quay namespace
-context = os.environ["DOCKER_CONTEXT"] # Build Context
-github_repo = os.environ["GITHUB_REPO"] # Name of repo on github
-suffix = ""
-if "SUFFIX" in os.environ:
-    suffix = f"-{os.environ['SUFFIX']}"
-
-
 def print_api_error(status_code: int) -> None:
     errors = {400: "Bad Request",
               401: "Session required",
@@ -32,6 +22,9 @@ def print_api_error(status_code: int) -> None:
 
 def load_readme_as_list(dir: str) -> Optional[List[str]]:
     readme_path = os.path.join(dir, "README.md")
+    if not os.path.isfile(readme_path):
+        print(f"Invalid path: {readme_path} does not exist")
+        return None
     with open(readme_path) as readme:
         lines = readme.readlines()
         for i, line in enumerate(lines):
@@ -39,11 +32,22 @@ def load_readme_as_list(dir: str) -> Optional[List[str]]:
                 if i + 3 >= len(lines):
                     break
                 return lines[i + 3:]
+    print("Invalid README format")
     return None
 
 
+def escape_code_block(lines: List[str]):
+    backtick_count = 0
+    for line in lines:
+        if "```" in line:
+            backtick_count += 1
+    if backtick_count % 2 == 1:
+        lines.append("...\n```")
+    return lines
+
+
 def update_description(readme: str) -> int:
-    api_request_path = f"https://quay.io/api/v1/repository/{registry_namespace}/{image_name}{suffix}"
+    api_request_path = f"https://quay.io/api/v1/repository/{registry_namespace}/{image_name}"
     headers = {"Content-Type": "application/json",
                "Authorization": f"Bearer {token}"}
     data = {"description": readme}
@@ -52,18 +56,20 @@ def update_description(readme: str) -> int:
 
 
 if __name__ == "__main__":
-    if registry_namespace != "sclorg" and registry_namespace != "centos7":
-        print("Invalid namespace. This script supports only sclorg and centos7 namespaces")
-        sys.exit(1)
-
+    token = os.environ["REGISTRY_TOKEN"] # Quay token
+    image_name = os.environ["IMAGE_NAME"] # Quay image name
+    registry_namespace = os.environ["REGISTRY_NAMESPACE"] # Quay namespace
+    context = os.environ["DOCKER_CONTEXT"] # Build Context
+    github_repo = os.environ["GITHUB_REPO"] # Name of repo on github
+    
     readme_as_list = load_readme_as_list(context)
     if readme_as_list is None:
-        print("Invalid README format")
         sys.exit(1)
     if len(readme_as_list) > 100:
         readme_as_list = readme_as_list[:98]
+        escape_code_block(readme_as_list)
         readme_as_list.append("\n<br>\n")
-        readme_as_list.append(f"Learn more at <https://github.com/sclorg/{github_repo}/{context}/README.md>")
+        readme_as_list.append(f"Learn more at <https://github.com/sclorg/{github_repo}/blob//master/{context}/README.md>")
     
     readme = "".join(readme_as_list)
     request_status = update_description(readme)

--- a/jenkins_ci/update_quay_description.py
+++ b/jenkins_ci/update_quay_description.py
@@ -44,7 +44,6 @@ def load_readme_as_list(dir: str) -> Optional[List[str]]:
 
 def update_description(readme: str) -> int:
     api_request_path = f"https://quay.io/api/v1/repository/{registry_namespace}/{image_name}{suffix}"
-    print(api_request_path)
     headers = {"Content-Type": "application/json",
                "Authorization": f"Bearer {token}"}
     data = {"description": readme}

--- a/jenkins_ci/update_quay_description.py
+++ b/jenkins_ci/update_quay_description.py
@@ -63,7 +63,7 @@ if __name__ == "__main__":
         sys.exit(1)
     if len(readme_as_list) > 100:
         readme_as_list = readme_as_list[:98]
-        readme_as_list.append("```\n<br>\n")
+        readme_as_list.append("\n<br>\n")
         readme_as_list.append(f"Learn more at <https://github.com/sclorg/{github_repo}/{context}/README.md>")
     
     readme = "".join(readme_as_list)

--- a/jenkins_ci/update_quay_description.py
+++ b/jenkins_ci/update_quay_description.py
@@ -71,3 +71,4 @@ if __name__ == "__main__":
     if request_status != 200:
         print_api_error(request_status)
         sys.exit(1)
+    print("Operation successful")

--- a/jenkins_ci/update_quay_description.py
+++ b/jenkins_ci/update_quay_description.py
@@ -4,76 +4,88 @@
 
 import os
 import sys
-import re
 import requests
 from typing import Optional, List
 
 
 def print_api_error(status_code: int) -> None:
-    errors = {400: "Bad Request",
-              401: "Session required",
-              403: "Unauthorized access",
-              404: "Not found"}
+    errors = {
+        400: "Bad Request",
+        401: "Session required",
+        403: "Unauthorized access",
+        404: "Not found"
+    }
     if status_code not in errors.keys():
         print("Unknown API error")
     else:
         print(errors[status_code])
 
 
-def load_readme_as_list(dir: str) -> Optional[List[str]]:
+def load_readme(dir: str) -> Optional[str]:
     readme_path = os.path.join(dir, "README.md")
-    if not os.path.isfile(readme_path):
+    if not os.path.exists(readme_path):
         print(f"Invalid path: {readme_path} does not exist")
         return None
     with open(readme_path) as readme:
         lines = readme.readlines()
-        for i, line in enumerate(lines):
-            if re.match("Description", line):
-                if i + 3 >= len(lines):
-                    break
-                return lines[i + 3:]
-    print("Invalid README format")
-    return None
+        if len(lines) > 100:
+            lines = shorten_readme(lines)
+        return "".join(lines)
 
 
-def escape_code_block(lines: List[str]):
+def escape_code_block(lines: List[str]) -> None:
+    """
+    Ensures that all markdown code blocks created by backticks (```) are correctly 
+    closed, so that any lines added afterwards will be outside of a code block.
+    Unclosed code blocks can occur after shortening readme.
+    """
     backtick_count = 0
     for line in lines:
         if "```" in line:
             backtick_count += 1
     if backtick_count % 2 == 1:
         lines.append("...\n```")
-    return lines
 
 
-def update_description(readme: str) -> int:
-    api_request_path = f"https://quay.io/api/v1/repository/{registry_namespace}/{image_name}"
-    headers = {"Content-Type": "application/json",
-               "Authorization": f"Bearer {token}"}
-    data = {"description": readme}
-    r = requests.put(api_request_path, headers=headers, json=data)
-    return r.status_code
+def shorten_readme(readme_as_list: List[str]) -> List[str]:
+    """
+    Shorten readme if it is too long
+    """
+    readme_as_list = readme_as_list[:98]
+    escape_code_block(readme_as_list) 
+    readme_as_list.append("\n<br>\n")
+    readme_as_list.append(f"Learn more at <https://github.com/sclorg/{github_repo}/blob//master/{context}/README.md>")
+    return readme_as_list
+
+
+def update_description(readme: str) -> bool:
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {token}"
+    }
+    data = {
+        "description": readme
+    }
+    r = requests.put(API_REQUEST_PATH, headers=headers, json=data)
+    if r.status_code != 200:
+        print_api_error(r.status_code)
+        return False
+    return True
 
 
 if __name__ == "__main__":
-    token = os.environ["REGISTRY_TOKEN"] # Quay token
+    token = os.environ["QUAY_IMAGE_UPDATE_DESC"] # Quay token
     image_name = os.environ["IMAGE_NAME"] # Quay image name
     registry_namespace = os.environ["REGISTRY_NAMESPACE"] # Quay namespace
     context = os.environ["DOCKER_CONTEXT"] # Build Context
     github_repo = os.environ["GITHUB_REPO"] # Name of repo on github
+
+    API_REQUEST_PATH = f"https://quay.io/api/v1/repository/{registry_namespace}/{image_name}"
     
-    readme_as_list = load_readme_as_list(context)
-    if readme_as_list is None:
+    readme = load_readme(context)
+    if readme is None:
         sys.exit(1)
-    if len(readme_as_list) > 100:
-        readme_as_list = readme_as_list[:98]
-        escape_code_block(readme_as_list)
-        readme_as_list.append("\n<br>\n")
-        readme_as_list.append(f"Learn more at <https://github.com/sclorg/{github_repo}/blob//master/{context}/README.md>")
-    
-    readme = "".join(readme_as_list)
-    request_status = update_description(readme)
-    if request_status != 200:
-        print_api_error(request_status)
+
+    if not update_description(readme):
         sys.exit(1)
     print("Operation successful")


### PR DESCRIPTION
To run this script locally:
1. Ensure that your current working directory is the root directory of the container whose description you want to update
2. Run the following: 
```
REGISTRY_TOKEN=<quay-registry-token>  \
IMAGE_NAME=<quay-image-name> \
REGISTRY_NAMESPACE=<quay-registry-namespace> \
DOCKER_CONTEXT=<build-context> \
GITHUB_REPO=<container-repo-github-name> \
<path-to-this-script>
```
Eg.
```
REGISTRY_TOKEN=<quay-registry-token >  \
IMAGE_NAME=postgresql-15-c9s \
REGISTRY_NAMESPACE=sclorg \
DOCKER_CONTEXT=15 \
GITHUB_REPO=postgresql-container \
<path-to-this-script>
```