### PR TITLE
Fix CI sanity report.

### DIFF
--- a/daily_tests/sclorg_sanity_tests.py
+++ b/daily_tests/sclorg_sanity_tests.py
@@ -35,7 +35,6 @@ SCLORG_REPOS = {
 
 OS_HOSTS = [
     "fedora",
-    "centos7",
     "c9s",
     "c8s",
     "rhel7",
@@ -267,6 +266,8 @@ class SclOrgSanityChecker(object):
                 if not checker:
                     self.write_to_textfile(msg=self.message, report_file=report_file)
                     sanity_ok = False
+                else:
+                    self.update_message(msg=f"{ver} is ok.")
             if sanity_ok:
                 if Path(report_file).exists():
                     os.unlink(report_file)

--- a/daily_tests/sclorg_sanity_tests.py
+++ b/daily_tests/sclorg_sanity_tests.py
@@ -245,11 +245,12 @@ class SclOrgSanityChecker(object):
                 self.data_dict[repo][ver] = self.check_files(ver)
             os.chdir(self.cwd)
             rmtree(self.tmp_path_dir / repo)
-        print(self.data_dict)
 
     def run_check(self):
         for repo in self.data_dict:
             report_file = Path(self.log_dir) / f"{repo}.log"
+            if report_file.exists():
+                report_file.unlink()
             self.repo = repo
             self.pkg_name = SCLORG_REPOS[repo]
             sanity_ok = True
@@ -269,7 +270,7 @@ class SclOrgSanityChecker(object):
                 else:
                     self.update_message(msg=f"{ver} is ok.")
             if sanity_ok:
-                if Path(report_file).exists():
+                if report_file.exists():
                     os.unlink(report_file)
             else:
                 if repo not in self.failed_repos:


### PR DESCRIPTION
Fix CI sanity report

Get rid off CentOS7 and remove previous logs.
<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
