### PR TITLE
Imagestream generator

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,20 @@
+---
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
+name: Run Tox tests on ci-scripts
+jobs:
+  tox_test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: fedora-python/tox-github-action@main
+      with:
+        tox_env: py311
+        workdir: "ocp-stream-generator/"
+...

--- a/ocp-stream-generator/LICENSE.txt
+++ b/ocp-stream-generator/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Red Hat, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/ocp-stream-generator/README.md
+++ b/ocp-stream-generator/README.md
@@ -1,0 +1,36 @@
+**ocp-stream-generator**
+
+The ocp generator tool generates JSON files that are consumed by the OpenShift cluster.
+Adding support for generating HelmCharts is planned for the future.
+
+
+For now the generator takes only one argument, which is YAML config file.
+The configuration file should look like this:
+
+```
+---
+- name: postgresql
+  pretty_name: PostgreSQL
+  sample_repo: ""
+  category: database
+  description: >
+    Provides a PostgreSQL APP_VERSION database on DISTRO_NAME.
+    For more information about using this database image,
+    including OpenShift considerations,
+    see https://github.com/sclorg/postgresql-container/blob/master/README.md.
+  imagestream_files:
+  - filename: postgresql-centos.json
+    latest: "15-el9"
+    distros:
+      - name: CentOS Stream 8
+        app_versions: [10, 12, 13, 15]
+
+      - name: CentOS Stream 9
+        app_versions: [13, 15]
+
+  - filename: postgresql-rhel.json
+    latest: "13-el7"
+    distros:
+      - name: RHEL 7
+        app_versions: [10, 12, 13]
+```

--- a/ocp-stream-generator/ocp-stream-generator/distribution_data.py
+++ b/ocp-stream-generator/ocp-stream-generator/distribution_data.py
@@ -1,0 +1,44 @@
+# MIT License
+#
+# Copyright (c) 2024 Red Hat, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+images = {"RHEL 7": "registry.redhat.io/rhscl/APP_NAME-APP_VERSION-rhel7:latest",
+          "RHEL 8": "registry.redhat.io/rhel8/APP_NAME-APP_VERSION:latest",
+          "RHEL 9": "registry.redhat.io/rhel9/APP_NAME-APP_VERSION:latest",
+          "UBI 7": "registry.redhat.io/ubi7/APP_NAME-APP_VERSION:latest",
+          "UBI 8": "registry.redhat.io/ubi8/APP_NAME-APP_VERSION:latest",
+          "UBI 9": "registry.redhat.io/ubi9/APP_NAME-APP_VERSION:latest",
+          "CentOS Stream 8": "quay.io/sclorg/APP_NAME-APP_VERSION-c8s:latest",
+          "CentOS Stream 9": "quay.io/sclorg/APP_NAME-APP_VERSION-c9s:latest"}
+
+abbreviations ={"RHEL 7": "el7",
+                "RHEL 8": "el8",
+                "RHEL 9": "el9",
+                "UBI 7": "ubi7",
+                "UBI 8": "ubi8",
+                "UBI 9": "ubi9",
+                "CentOS Stream 8": "el8",
+                "CentOS Stream 9": "el9"}
+
+latest_description = """
+
+WARNING: By selecting this tag, your application will automatically update to use the latest version available on OpenShift, including major version updates.
+"""

--- a/ocp-stream-generator/ocp-stream-generator/stream_generator.py
+++ b/ocp-stream-generator/ocp-stream-generator/stream_generator.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+
+# MIT License
+#
+# Copyright (c) 2024 Red Hat, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+import yaml
+import json
+import sys
+from distribution_data import abbreviations, images, latest_description
+
+class YamlLoader:
+    data = None
+    yaml_path = None
+
+    def __init__(self, yaml):
+        self.yaml_path = yaml
+
+    @property
+    def json_data(self):
+        if not self.data:
+            with open(self.yaml_path,'r') as file:
+                self.data = yaml.safe_load(file)[0]
+        return self.data
+
+
+class ImagestreamFile:
+    filename: str
+    tags =  None
+    latest_tag = None
+    app_name: str
+    app_pretty_name: str
+    is_correct = True
+
+    # The mapping of stream names to distros is not 1 to 1.
+    # For example stream name el8-16 can be RHEL8 or CentOS Stream 8 distro.
+    # As the Latest tag is defined by the stream name only,
+    # we need go through all tags in Image Stream File and return
+    # a distro of a tag with the same stream name.
+    def obtain_distro_for_latest(self, stream_name):
+        for tag in self.tags:
+            if tag.stream_name == stream_name:
+                return tag.distro_name
+        print("The stream name of the latest tag was not found in the rest of tags")
+        self.is_correct = False
+
+
+    def __init__(self, file, header):
+        self.app_name = header['name']
+        self.app_pretty_name = header['pretty_name']
+        self.filename = file['filename']
+        self.tags = []
+        for distro in file['distros']:
+            for app_version in distro['app_versions']:
+                _tag = Tag(header, distro['name'], version=app_version)
+                self.tags.append(_tag)
+        _latest_distro = self.obtain_distro_for_latest(file['latest']);
+        if not _latest_distro:
+            return
+        self.latest_tag = Tag(header, _latest_distro, latest=file['latest'])
+
+
+class Tag:
+    stream_name: str
+    version: int
+    distro_name: str
+    image: str
+    description: str
+    sample_repo = None
+    app_name: str
+    app_pretty_name: str
+    latest = None
+    category: str
+
+    def obtain_stream_name(self):
+        if self.latest:
+            return "latest"
+        else:
+            return str(self.version) + "-" + abbreviations[self.distro_name]
+
+    def obtain_version(self, version):
+        if self.latest:
+            return self.latest.split('-',1)[0]
+        else:
+            return version
+
+    def obtain_image(self):
+        if self.latest:
+            return self.latest
+        else:
+            return images[self.distro_name] \
+                .replace("APP_VERSION", str(self.version)) \
+                .replace("APP_NAME", self.app_name)
+
+    def __init__(self, header, distro_name, version=None, latest=None):
+        self.category = header['category']
+        self.app_name = header['name']
+        self.app_pretty_name = header['pretty_name']
+        self.sample_repo = header['sample_repo']
+        self.latest = latest
+        self.version = self.obtain_version(version)
+        self.distro_name = distro_name
+        self.description = header['description'] \
+            .replace("APP_VERSION", str(self.version)) \
+            .replace("DISTRO_NAME", self.distro_name)
+
+        self.image = self.obtain_image()
+        self.stream_name = self.obtain_stream_name()
+        if self.latest:
+            self.description += latest_description
+
+
+class JsonBuilder:
+    def create_header(self, data):
+        _header = {}
+        _header['kind'] = "ImageStream"
+        _header['apiVersion'] = "image.openshift.io/v1"
+        _header['metadata'] =  {
+                                 "name": data.app_name,
+                                 "annotations": {
+                                    "openshift.io/display-name": data.app_pretty_name
+                                 }
+                               }
+        _header['spec'] = {'tags': []}
+        return _header
+
+    def create_annotation(self, tag):
+        _ann = {}
+        _disp_name = tag.app_pretty_name + " " + str(tag.version)
+        if tag.latest:
+            _disp_name +=" (Latest)"
+        else:
+            _disp_name += " ("+ tag.distro_name +")"
+        _ann['openshift.io/display-name'] = _disp_name
+        _ann['openshift.io/provider-display-name'] =  "Red Hat, Inc."
+        _ann['description'] = tag.description
+        _ann['iconClass'] = "icon-" + tag.app_name
+        _ann['tags'] = tag.category + "," + tag.app_name
+        _ann['version'] = str(tag.version)
+        if tag.sample_repo != "":
+            _ann['sampleRepo'] = tag.sample_repo
+        return _ann
+
+
+    def add_tag(self, _json, tag):
+        _tag = {}
+        _tag['name'] = tag.stream_name
+        _tag['annotations'] = self.create_annotation(tag)
+        if tag.latest:
+            _tag['from'] = {"kind": "ImageStreamTag", "name": tag.image}
+        else:
+            _tag['from'] = {"kind": "DockerImage", "name": tag.image}
+        _tag['referencePolicy'] = {"type": "Local"}
+        _json['spec']['tags'].append(_tag)
+        return _json
+
+    def generate_json(self, isf_data):
+        _json = {}
+        _json = self.create_header(isf_data)
+        for tag in isf_data.tags:
+            _json = self.add_tag(_json, tag)
+        self.add_tag(_json, isf_data.latest_tag)
+        return json.dumps(_json, indent=2)
+
+def main():
+    if len(sys.argv) != 2:
+        print("please provide YAML conf file as first parameter of this script")
+        return 5
+    yaml_loader = YamlLoader(sys.argv[1])
+    builder = JsonBuilder()
+
+    isf_header = yaml_loader.json_data
+    is_files = isf_header.pop('imagestream_files')
+    for isf in is_files:
+        isf_data = ImagestreamFile(isf, isf_header)
+        if not isf_data.is_correct:
+            return 5
+        with open(isf_data.filename, "w") as json_file:
+            json_file.write(builder.generate_json(isf_data)+ "\n")
+
+if __name__ == '__main__':
+    main();
+

--- a/ocp-stream-generator/ocp-stream-generator/stream_generator.py
+++ b/ocp-stream-generator/ocp-stream-generator/stream_generator.py
@@ -38,7 +38,7 @@ class YamlLoader:
     @property
     def json_data(self):
         if not self.data:
-            with open(self.yaml_path,'r') as file:
+            with open(self.yaml_path,"r") as file:
                 self.data = yaml.safe_load(file)[0]
         return self.data
 
@@ -65,18 +65,18 @@ class ImagestreamFile:
 
 
     def __init__(self, file, header):
-        self.app_name = header['name']
-        self.app_pretty_name = header['pretty_name']
-        self.filename = file['filename']
+        self.app_name = header["name"]
+        self.app_pretty_name = header["pretty_name"]
+        self.filename = file["filename"]
         self.tags = []
-        for distro in file['distros']:
-            for app_version in distro['app_versions']:
-                _tag = Tag(header, distro['name'], version=app_version)
+        for distro in file["distros"]:
+            for app_version in distro["app_versions"]:
+                _tag = Tag(header, distro["name"], version=app_version)
                 self.tags.append(_tag)
-        _latest_distro = self.obtain_distro_for_latest(file['latest']);
+        _latest_distro = self.obtain_distro_for_latest(file["latest"]);
         if not _latest_distro:
             return
-        self.latest_tag = Tag(header, _latest_distro, latest=file['latest'])
+        self.latest_tag = Tag(header, _latest_distro, latest=file["latest"])
 
 
 class Tag:
@@ -99,7 +99,7 @@ class Tag:
 
     def obtain_version(self, version):
         if self.latest:
-            return self.latest.split('-',1)[0]
+            return self.latest.split("-",1)[0]
         else:
             return version
 
@@ -112,14 +112,14 @@ class Tag:
                 .replace("APP_NAME", self.app_name)
 
     def __init__(self, header, distro_name, version=None, latest=None):
-        self.category = header['category']
-        self.app_name = header['name']
-        self.app_pretty_name = header['pretty_name']
-        self.sample_repo = header['sample_repo']
+        self.category = header["category"]
+        self.app_name = header["name"]
+        self.app_pretty_name = header["pretty_name"]
+        self.sample_repo = header["sample_repo"]
         self.latest = latest
         self.version = self.obtain_version(version)
         self.distro_name = distro_name
-        self.description = header['description'] \
+        self.description = header["description"] \
             .replace("APP_VERSION", str(self.version)) \
             .replace("DISTRO_NAME", self.distro_name)
 
@@ -132,15 +132,15 @@ class Tag:
 class JsonBuilder:
     def create_header(self, data):
         _header = {}
-        _header['kind'] = "ImageStream"
-        _header['apiVersion'] = "image.openshift.io/v1"
-        _header['metadata'] =  {
+        _header["kind"] = "ImageStream"
+        _header["apiVersion"] = "image.openshift.io/v1"
+        _header["metadata"] =  {
                                  "name": data.app_name,
                                  "annotations": {
                                     "openshift.io/display-name": data.app_pretty_name
                                  }
                                }
-        _header['spec'] = {'tags': []}
+        _header["spec"] = {"tags": []}
         return _header
 
     def create_annotation(self, tag):
@@ -150,27 +150,27 @@ class JsonBuilder:
             _disp_name +=" (Latest)"
         else:
             _disp_name += " ("+ tag.distro_name +")"
-        _ann['openshift.io/display-name'] = _disp_name
-        _ann['openshift.io/provider-display-name'] =  "Red Hat, Inc."
-        _ann['description'] = tag.description
-        _ann['iconClass'] = "icon-" + tag.app_name
-        _ann['tags'] = tag.category + "," + tag.app_name
-        _ann['version'] = str(tag.version)
+        _ann["openshift.io/display-name"] = _disp_name
+        _ann["openshift.io/provider-display-name"] =  "Red Hat, Inc."
+        _ann["description"] = tag.description
+        _ann["iconClass"] = "icon-" + tag.app_name
+        _ann["tags"] = tag.category + "," + tag.app_name
+        _ann["version"] = str(tag.version)
         if tag.sample_repo != "":
-            _ann['sampleRepo'] = tag.sample_repo
+            _ann["sampleRepo"] = tag.sample_repo
         return _ann
 
 
     def add_tag(self, _json, tag):
         _tag = {}
-        _tag['name'] = tag.stream_name
-        _tag['annotations'] = self.create_annotation(tag)
+        _tag["name"] = tag.stream_name
+        _tag["annotations"] = self.create_annotation(tag)
         if tag.latest:
-            _tag['from'] = {"kind": "ImageStreamTag", "name": tag.image}
+            _tag["from"] = {"kind": "ImageStreamTag", "name": tag.image}
         else:
-            _tag['from'] = {"kind": "DockerImage", "name": tag.image}
-        _tag['referencePolicy'] = {"type": "Local"}
-        _json['spec']['tags'].append(_tag)
+            _tag["from"] = {"kind": "DockerImage", "name": tag.image}
+        _tag["referencePolicy"] = {"type": "Local"}
+        _json["spec"]["tags"].append(_tag)
         return _json
 
     def generate_json(self, isf_data):
@@ -189,7 +189,7 @@ def main():
     builder = JsonBuilder()
 
     isf_header = yaml_loader.json_data
-    is_files = isf_header.pop('imagestream_files')
+    is_files = isf_header.pop("imagestream_files")
     for isf in is_files:
         isf_data = ImagestreamFile(isf, isf_header)
         if not isf_data.is_correct:
@@ -197,6 +197,6 @@ def main():
         with open(isf_data.filename, "w") as json_file:
             json_file.write(builder.generate_json(isf_data)+ "\n")
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main();
 

--- a/ocp-stream-generator/ocp-stream-generator/stream_generator.py
+++ b/ocp-stream-generator/ocp-stream-generator/stream_generator.py
@@ -95,7 +95,7 @@ class Tag:
         if self.latest:
             return "latest"
         else:
-            return str(self.version) + "-" + abbreviations[self.distro_name]
+            return f"{str(self.version)}-{abbreviations[self.distro_name]}"
 
     def obtain_version(self, version):
         if self.latest:
@@ -145,16 +145,16 @@ class JsonBuilder:
 
     def create_annotation(self, tag):
         _ann = {}
-        _disp_name = tag.app_pretty_name + " " + str(tag.version)
+        _disp_name = f"{tag.app_pretty_name} {str(tag.version)}"
         if tag.latest:
-            _disp_name +=" (Latest)"
+            _disp_name += " (Latest)"
         else:
-            _disp_name += " ("+ tag.distro_name +")"
+            _disp_name += f" ({tag.distro_name})"
         _ann["openshift.io/display-name"] = _disp_name
         _ann["openshift.io/provider-display-name"] =  "Red Hat, Inc."
         _ann["description"] = tag.description
-        _ann["iconClass"] = "icon-" + tag.app_name
-        _ann["tags"] = tag.category + "," + tag.app_name
+        _ann["iconClass"] = f"icon-{tag.app_name}"
+        _ann["tags"] = f"{tag.category},{tag.app_name}"
         _ann["version"] = str(tag.version)
         if tag.sample_repo != "":
             _ann["sampleRepo"] = tag.sample_repo

--- a/ocp-stream-generator/ocp-stream-generator/stream_generator.py
+++ b/ocp-stream-generator/ocp-stream-generator/stream_generator.py
@@ -29,18 +29,18 @@ import sys
 from distribution_data import abbreviations, images, latest_description
 
 class YamlLoader:
-    data = None
+    _data = None
     yaml_path = None
 
     def __init__(self, yaml):
         self.yaml_path = yaml
 
     @property
-    def json_data(self):
-        if not self.data:
+    def data(self):
+        if not self._data:
             with open(self.yaml_path,"r") as file:
-                self.data = yaml.safe_load(file)[0]
-        return self.data
+                self._data = yaml.safe_load(file)[0]
+        return self._data
 
 
 class ImagestreamFile:
@@ -188,7 +188,7 @@ def main():
     yaml_loader = YamlLoader(sys.argv[1])
     builder = JsonBuilder()
 
-    isf_header = yaml_loader.json_data
+    isf_header = yaml_loader.data
     is_files = isf_header.pop("imagestream_files")
     for isf in is_files:
         isf_data = ImagestreamFile(isf, isf_header)

--- a/ocp-stream-generator/pytest.ini
+++ b/ocp-stream-generator/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+pythonpath = ocp-stream-generator
+testpaths = tests

--- a/ocp-stream-generator/tests/data/data_json_builder.py
+++ b/ocp-stream-generator/tests/data/data_json_builder.py
@@ -1,4 +1,15 @@
-result_json = """
+add_tag_result = {"spec": {"tags": [{"name": "1-el8", "annotations": {"openshift.io/display-name": "Test 1 (RHEL 8)", "openshift.io/provider-display-name": "Red Hat, Inc.", "description": "test description", "iconClass": "icon-test", "tags": "test,test", "version": "1"}, "from": {"kind": "DockerImage", "name": "registry.redhat.io/rhel8/test-1:latest"}, "referencePolicy": {"type": "Local"}}]}}
+
+add_tag_latest_result = {"spec": {"tags": [{"name": "latest", "annotations": {"openshift.io/display-name": "Test 1 (Latest)", "openshift.io/provider-display-name": "Red Hat, Inc.", "description": "test description\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version available on OpenShift, including major version updates.\n", "iconClass": "icon-test", "tags": "test,test", "version": "1"}, "from": {"kind": "ImageStreamTag", "name": "1-el8"}, "referencePolicy": {"type": "Local"}}]}}
+
+create_annotation_result = {"openshift.io/display-name": "Test 1 (RHEL 8)", "openshift.io/provider-display-name": "Red Hat, Inc.", "description": "test description", "iconClass": "icon-test", "tags": "test,test", "version": "1"}
+
+create_annotation_latest_result = {"openshift.io/display-name": "Test 1 (Latest)", "openshift.io/provider-display-name": "Red Hat, Inc.", "description": "test description\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version available on OpenShift, including major version updates.\n", "iconClass": "icon-test", "tags": "test,test", "version": "1"}
+
+create_header_result = {"kind": "ImageStream", "apiVersion": "image.openshift.io/v1", "metadata": {"name": "test", "annotations": {"openshift.io/display-name": "Test"}}, "spec": {"tags": []}}
+
+
+generate_json_result = """
 {
   "kind": "ImageStream",
   "apiVersion": "image.openshift.io/v1",

--- a/ocp-stream-generator/tests/data/data_json_builder.py
+++ b/ocp-stream-generator/tests/data/data_json_builder.py
@@ -1,0 +1,52 @@
+result_json = """
+{
+  "kind": "ImageStream",
+  "apiVersion": "image.openshift.io/v1",
+  "metadata": {
+    "name": "test",
+    "annotations": {
+      "openshift.io/display-name": "Test"
+    }
+  },
+  "spec": {
+    "tags": [
+      {
+        "name": "1-el8",
+        "annotations": {
+          "openshift.io/display-name": "Test 1 (RHEL 8)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "test description",
+          "iconClass": "icon-test",
+          "tags": "test,test",
+          "version": "1"
+        },
+        "from": {
+          "kind": "DockerImage",
+          "name": "registry.redhat.io/rhel8/test-1:latest"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      },
+      {
+        "name": "latest",
+        "annotations": {
+          "openshift.io/display-name": "Test 1 (Latest)",
+          "openshift.io/provider-display-name": "Red Hat, Inc.",
+          "description": "test description\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version available on OpenShift, including major version updates.\n",
+          "iconClass": "icon-test",
+          "tags": "test,test",
+          "version": "1"
+        },
+        "from": {
+          "kind": "ImageStreamTag",
+          "name": "1-el8"
+        },
+        "referencePolicy": {
+          "type": "Local"
+        }
+      }
+    ]
+  }
+}
+"""

--- a/ocp-stream-generator/tests/data/data_yaml_loader.py
+++ b/ocp-stream-generator/tests/data/data_yaml_loader.py
@@ -1,0 +1,1 @@
+load_yaml_result = {"name": "test_pkg", "pretty_name": "Test Package", "sample_repo": "", "category": "testing", "description": "Let's test this!", "imagestream_files": [{"filename": "test-centos.json", "latest": "2-el9", "distros": [{"name": "CentOS Stream 8", "app_versions": [2, 3, 1]}, {"name": "CentOS Stream 9", "app_versions": [2]}]}]}

--- a/ocp-stream-generator/tests/data/minimal.yml
+++ b/ocp-stream-generator/tests/data/minimal.yml
@@ -1,0 +1,16 @@
+---
+- name: test_pkg
+  pretty_name: Test Package
+  sample_repo: ""
+  category: testing
+  description: Let's test this!
+  imagestream_files:
+  - filename: test-centos.json
+    latest: "2-el9"
+    distros:
+      - name: CentOS Stream 8
+        app_versions: [2, 3, 1]
+
+      - name: CentOS Stream 9
+        app_versions: [2]
+...

--- a/ocp-stream-generator/tests/test_imagestream_file.py
+++ b/ocp-stream-generator/tests/test_imagestream_file.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+
+import pytest
+import sys
+import re
+from stream_generator import ImagestreamFile
+
+
+
+def test_create_isf():
+    isf = {'filename': 'test-centos.json', 'latest': '2-el9', 'distros': [{'name': 'CentOS Stream 8', 'app_versions': [2, 3, 1]}, {'name': 'CentOS Stream 9', 'app_versions': [2]}]}
+    isf_header = {'name': 'test_pkg', 'pretty_name': 'Test Package', 'sample_repo': '', 'category': 'testing', 'description': "Let's test this!"}
+    isf_data = ImagestreamFile(isf, isf_header)
+    assert isf_data.latest_tag.latest == "2-el9"
+    assert isf_data.app_pretty_name == "Test Package"
+    assert isf_data.app_name == "test_pkg"
+    assert isf_data.latest_tag.distro_name == "CentOS Stream 9"
+    assert isf_data.tags[0].description == "Let's test this!"

--- a/ocp-stream-generator/tests/test_imagestream_file.py
+++ b/ocp-stream-generator/tests/test_imagestream_file.py
@@ -8,8 +8,8 @@ from stream_generator import ImagestreamFile
 
 
 def test_create_isf():
-    isf = {'filename': 'test-centos.json', 'latest': '2-el9', 'distros': [{'name': 'CentOS Stream 8', 'app_versions': [2, 3, 1]}, {'name': 'CentOS Stream 9', 'app_versions': [2]}]}
-    isf_header = {'name': 'test_pkg', 'pretty_name': 'Test Package', 'sample_repo': '', 'category': 'testing', 'description': "Let's test this!"}
+    isf = {"filename": "test-centos.json", "latest": "2-el9", "distros": [{"name": "CentOS Stream 8", "app_versions": [2, 3, 1]}, {"name": "CentOS Stream 9", "app_versions": [2]}]}
+    isf_header = {"name": "test_pkg", "pretty_name": "Test Package", "sample_repo": "", "category": "testing", "description": "Let's test this!"}
     isf_data = ImagestreamFile(isf, isf_header)
     assert isf_data.latest_tag.latest == "2-el9"
     assert isf_data.app_pretty_name == "Test Package"

--- a/ocp-stream-generator/tests/test_json_builder.py
+++ b/ocp-stream-generator/tests/test_json_builder.py
@@ -6,7 +6,12 @@ import re
 from stream_generator import JsonBuilder
 from stream_generator import Tag
 from stream_generator import ImagestreamFile
-from data.data_json_builder import result_json
+from data.data_json_builder import add_tag_result
+from data.data_json_builder import add_tag_latest_result
+from data.data_json_builder import create_annotation_result
+from data.data_json_builder import create_annotation_latest_result
+from data.data_json_builder import create_header_result
+from data.data_json_builder import generate_json_result
 builder = JsonBuilder()
 
 header = {"name": "test", "pretty_name": "Test", "sample_repo": "", "category": "test", "description": "test description"}
@@ -15,23 +20,19 @@ header = {"name": "test", "pretty_name": "Test", "sample_repo": "", "category": 
 
 def test_add_tag():
     tag = Tag(header, "RHEL 8", version=1)
-    result = {"spec": {"tags": [{"name": "1-el8", "annotations": {"openshift.io/display-name": "Test 1 (RHEL 8)", "openshift.io/provider-display-name": "Red Hat, Inc.", "description": "test description", "iconClass": "icon-test", "tags": "test,test", "version": "1"}, "from": {"kind": "DockerImage", "name": "registry.redhat.io/rhel8/test-1:latest"}, "referencePolicy": {"type": "Local"}}]}}
-    assert builder.add_tag({"spec": { "tags": []}}, tag)  ==  result
+    assert builder.add_tag({"spec": { "tags": []}}, tag)  ==  add_tag_result
 
 def test_add_latest_tag():
     tag_latest = Tag(header, "RHEL8", latest="1-el8")
-    result_latest = {"spec": {"tags": [{"name": "latest", "annotations": {"openshift.io/display-name": "Test 1 (Latest)", "openshift.io/provider-display-name": "Red Hat, Inc.", "description": "test description\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version available on OpenShift, including major version updates.\n", "iconClass": "icon-test", "tags": "test,test", "version": "1"}, "from": {"kind": "ImageStreamTag", "name": "1-el8"}, "referencePolicy": {"type": "Local"}}]}}
-    assert builder.add_tag({"spec": { "tags": []}}, tag_latest)  ==  result_latest
+    assert builder.add_tag({"spec": { "tags": []}}, tag_latest)  ==  add_tag_latest_result
 
 def test_create_annotation():
     tag = Tag(header, "RHEL 8", version=1)
-    result = {"openshift.io/display-name": "Test 1 (RHEL 8)", "openshift.io/provider-display-name": "Red Hat, Inc.", "description": "test description", "iconClass": "icon-test", "tags": "test,test", "version": "1"}
-    assert builder.create_annotation(tag) == result
+    assert builder.create_annotation(tag) == create_annotation_result
 
 def test_create_annotation_latest():
     latest_tag = Tag(header, "RHEL 8", latest="1-el8")
-    latest_result = {"openshift.io/display-name": "Test 1 (Latest)", "openshift.io/provider-display-name": "Red Hat, Inc.", "description": "test description\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version available on OpenShift, including major version updates.\n", "iconClass": "icon-test", "tags": "test,test", "version": "1"}
-    assert builder.create_annotation(latest_tag) == latest_result
+    assert builder.create_annotation(latest_tag) == create_annotation_latest_result
 
 def test_create_header():
     header = {"name": "test", "pretty_name": "Test", "category": "test", \
@@ -39,8 +40,7 @@ def test_create_header():
     file = {"filename": "test-file.json", "distros": \
            [{"name": "RHEL 8", "app_versions": [1]}], "latest": "1-el8"}
     isf_data = ImagestreamFile(file, header)
-    result = {"kind": "ImageStream", "apiVersion": "image.openshift.io/v1", "metadata": {"name": "test", "annotations": {"openshift.io/display-name": "Test"}}, "spec": {"tags": []}}
-    assert builder.create_header(isf_data) == result
+    assert builder.create_header(isf_data) == create_header_result
 
 def test_generate_json():
     header = {"name": "test", "pretty_name": "Test", "category": "test", \
@@ -49,5 +49,5 @@ def test_generate_json():
            [{"name": "RHEL 8", "app_versions": [1]}], "latest": "1-el8"}
     isf_data = ImagestreamFile(file, header)
     stripped_json= re.sub(r"[\n\t\s\\n]*", "", builder.generate_json(isf_data))
-    stripped_result=re.sub(r"[\n\t\s\\n]*", "", result_json)
+    stripped_result=re.sub(r"[\n\t\s\\n]*", "", generate_json_result)
     assert stripped_json == stripped_result

--- a/ocp-stream-generator/tests/test_json_builder.py
+++ b/ocp-stream-generator/tests/test_json_builder.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+import pytest
+import sys
+import re
+from stream_generator import JsonBuilder
+from stream_generator import Tag
+from stream_generator import ImagestreamFile
+from data.data_json_builder import result_json
+builder = JsonBuilder()
+
+header = {'name': 'test', 'pretty_name': 'Test', 'sample_repo': '', 'category': 'test', 'description': 'test description'}
+
+
+
+def test_add_tag():
+    tag = Tag(header, "RHEL 8", version=1)
+    result = {'spec': {'tags': [{'name': '1-el8', 'annotations': {'openshift.io/display-name': 'Test 1 (RHEL 8)', 'openshift.io/provider-display-name': 'Red Hat, Inc.', 'description': 'test description', 'iconClass': 'icon-test', 'tags': 'test,test', 'version': '1'}, 'from': {'kind': 'DockerImage', 'name': 'registry.redhat.io/rhel8/test-1:latest'}, 'referencePolicy': {'type': 'Local'}}]}}
+    assert builder.add_tag({"spec": { "tags": []}}, tag)  ==  result
+
+def test_add_latest_tag():
+    tag_latest = Tag(header, "RHEL8", latest="1-el8")
+    result_latest = {'spec': {'tags': [{'name': 'latest', 'annotations': {'openshift.io/display-name': 'Test 1 (Latest)', 'openshift.io/provider-display-name': 'Red Hat, Inc.', 'description': 'test description\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version available on OpenShift, including major version updates.\n', 'iconClass': 'icon-test', 'tags': 'test,test', 'version': '1'}, 'from': {'kind': 'ImageStreamTag', 'name': '1-el8'}, 'referencePolicy': {'type': 'Local'}}]}}
+    assert builder.add_tag({"spec": { "tags": []}}, tag_latest)  ==  result_latest
+
+def test_create_annotation():
+    tag = Tag(header, "RHEL 8", version=1)
+    result = {'openshift.io/display-name': 'Test 1 (RHEL 8)', 'openshift.io/provider-display-name': 'Red Hat, Inc.', 'description': 'test description', 'iconClass': 'icon-test', 'tags': 'test,test', 'version': '1'}
+    assert builder.create_annotation(tag) == result
+
+def test_create_annotation_latest():
+    latest_tag = Tag(header, "RHEL 8", latest="1-el8")
+    latest_result = {'openshift.io/display-name': 'Test 1 (Latest)', 'openshift.io/provider-display-name': 'Red Hat, Inc.', 'description': 'test description\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version available on OpenShift, including major version updates.\n', 'iconClass': 'icon-test', 'tags': 'test,test', 'version': '1'}
+    assert builder.create_annotation(latest_tag) == latest_result
+
+def test_create_header():
+    header = {"name": "test", "pretty_name": "Test", "category": "test", \
+              "sample_repo": "", "description": "test description"}
+    file = {"filename": "test-file.json", "distros": \
+           [{"name": "RHEL 8", "app_versions": [1]}], "latest": "1-el8"}
+    isf_data = ImagestreamFile(file, header)
+    result = {'kind': 'ImageStream', 'apiVersion': 'image.openshift.io/v1', 'metadata': {'name': 'test', 'annotations': {'openshift.io/display-name': 'Test'}}, 'spec': {'tags': []}}
+    assert builder.create_header(isf_data) == result
+
+def test_generate_json():
+    header = {"name": "test", "pretty_name": "Test", "category": "test", \
+              "sample_repo": "", "description": "test description"}
+    file = {"filename": "test-file.json", "distros": \
+           [{"name": "RHEL 8", "app_versions": [1]}], "latest": "1-el8"}
+    isf_data = ImagestreamFile(file, header)
+    stripped_json= re.sub(r"[\n\t\s\\n]*", '', builder.generate_json(isf_data))
+    stripped_result=re.sub(r"[\n\t\s\\n]*", '', result_json)
+    assert stripped_json == stripped_result

--- a/ocp-stream-generator/tests/test_json_builder.py
+++ b/ocp-stream-generator/tests/test_json_builder.py
@@ -9,28 +9,28 @@ from stream_generator import ImagestreamFile
 from data.data_json_builder import result_json
 builder = JsonBuilder()
 
-header = {'name': 'test', 'pretty_name': 'Test', 'sample_repo': '', 'category': 'test', 'description': 'test description'}
+header = {"name": "test", "pretty_name": "Test", "sample_repo": "", "category": "test", "description": "test description"}
 
 
 
 def test_add_tag():
     tag = Tag(header, "RHEL 8", version=1)
-    result = {'spec': {'tags': [{'name': '1-el8', 'annotations': {'openshift.io/display-name': 'Test 1 (RHEL 8)', 'openshift.io/provider-display-name': 'Red Hat, Inc.', 'description': 'test description', 'iconClass': 'icon-test', 'tags': 'test,test', 'version': '1'}, 'from': {'kind': 'DockerImage', 'name': 'registry.redhat.io/rhel8/test-1:latest'}, 'referencePolicy': {'type': 'Local'}}]}}
+    result = {"spec": {"tags": [{"name": "1-el8", "annotations": {"openshift.io/display-name": "Test 1 (RHEL 8)", "openshift.io/provider-display-name": "Red Hat, Inc.", "description": "test description", "iconClass": "icon-test", "tags": "test,test", "version": "1"}, "from": {"kind": "DockerImage", "name": "registry.redhat.io/rhel8/test-1:latest"}, "referencePolicy": {"type": "Local"}}]}}
     assert builder.add_tag({"spec": { "tags": []}}, tag)  ==  result
 
 def test_add_latest_tag():
     tag_latest = Tag(header, "RHEL8", latest="1-el8")
-    result_latest = {'spec': {'tags': [{'name': 'latest', 'annotations': {'openshift.io/display-name': 'Test 1 (Latest)', 'openshift.io/provider-display-name': 'Red Hat, Inc.', 'description': 'test description\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version available on OpenShift, including major version updates.\n', 'iconClass': 'icon-test', 'tags': 'test,test', 'version': '1'}, 'from': {'kind': 'ImageStreamTag', 'name': '1-el8'}, 'referencePolicy': {'type': 'Local'}}]}}
+    result_latest = {"spec": {"tags": [{"name": "latest", "annotations": {"openshift.io/display-name": "Test 1 (Latest)", "openshift.io/provider-display-name": "Red Hat, Inc.", "description": "test description\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version available on OpenShift, including major version updates.\n", "iconClass": "icon-test", "tags": "test,test", "version": "1"}, "from": {"kind": "ImageStreamTag", "name": "1-el8"}, "referencePolicy": {"type": "Local"}}]}}
     assert builder.add_tag({"spec": { "tags": []}}, tag_latest)  ==  result_latest
 
 def test_create_annotation():
     tag = Tag(header, "RHEL 8", version=1)
-    result = {'openshift.io/display-name': 'Test 1 (RHEL 8)', 'openshift.io/provider-display-name': 'Red Hat, Inc.', 'description': 'test description', 'iconClass': 'icon-test', 'tags': 'test,test', 'version': '1'}
+    result = {"openshift.io/display-name": "Test 1 (RHEL 8)", "openshift.io/provider-display-name": "Red Hat, Inc.", "description": "test description", "iconClass": "icon-test", "tags": "test,test", "version": "1"}
     assert builder.create_annotation(tag) == result
 
 def test_create_annotation_latest():
     latest_tag = Tag(header, "RHEL 8", latest="1-el8")
-    latest_result = {'openshift.io/display-name': 'Test 1 (Latest)', 'openshift.io/provider-display-name': 'Red Hat, Inc.', 'description': 'test description\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version available on OpenShift, including major version updates.\n', 'iconClass': 'icon-test', 'tags': 'test,test', 'version': '1'}
+    latest_result = {"openshift.io/display-name": "Test 1 (Latest)", "openshift.io/provider-display-name": "Red Hat, Inc.", "description": "test description\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version available on OpenShift, including major version updates.\n", "iconClass": "icon-test", "tags": "test,test", "version": "1"}
     assert builder.create_annotation(latest_tag) == latest_result
 
 def test_create_header():
@@ -39,7 +39,7 @@ def test_create_header():
     file = {"filename": "test-file.json", "distros": \
            [{"name": "RHEL 8", "app_versions": [1]}], "latest": "1-el8"}
     isf_data = ImagestreamFile(file, header)
-    result = {'kind': 'ImageStream', 'apiVersion': 'image.openshift.io/v1', 'metadata': {'name': 'test', 'annotations': {'openshift.io/display-name': 'Test'}}, 'spec': {'tags': []}}
+    result = {"kind": "ImageStream", "apiVersion": "image.openshift.io/v1", "metadata": {"name": "test", "annotations": {"openshift.io/display-name": "Test"}}, "spec": {"tags": []}}
     assert builder.create_header(isf_data) == result
 
 def test_generate_json():
@@ -48,6 +48,6 @@ def test_generate_json():
     file = {"filename": "test-file.json", "distros": \
            [{"name": "RHEL 8", "app_versions": [1]}], "latest": "1-el8"}
     isf_data = ImagestreamFile(file, header)
-    stripped_json= re.sub(r"[\n\t\s\\n]*", '', builder.generate_json(isf_data))
-    stripped_result=re.sub(r"[\n\t\s\\n]*", '', result_json)
+    stripped_json= re.sub(r"[\n\t\s\\n]*", "", builder.generate_json(isf_data))
+    stripped_result=re.sub(r"[\n\t\s\\n]*", "", result_json)
     assert stripped_json == stripped_result

--- a/ocp-stream-generator/tests/test_yaml_loader.py
+++ b/ocp-stream-generator/tests/test_yaml_loader.py
@@ -4,8 +4,8 @@ import pytest
 import sys
 
 from stream_generator import YamlLoader
+from data.data_yaml_loader import load_yaml_result
 
 def test_load_yaml():
     loader = YamlLoader("tests/data/minimal.yml")
-    result = {"name": "test_pkg", "pretty_name": "Test Package", "sample_repo": "", "category": "testing", "description": "Let's test this!", "imagestream_files": [{"filename": "test-centos.json", "latest": "2-el9", "distros": [{"name": "CentOS Stream 8", "app_versions": [2, 3, 1]}, {"name": "CentOS Stream 9", "app_versions": [2]}]}]}
-    assert loader.json_data == result
+    assert loader.json_data == load_yaml_result

--- a/ocp-stream-generator/tests/test_yaml_loader.py
+++ b/ocp-stream-generator/tests/test_yaml_loader.py
@@ -7,5 +7,5 @@ from stream_generator import YamlLoader
 
 def test_load_yaml():
     loader = YamlLoader("tests/data/minimal.yml")
-    result = {'name': 'test_pkg', 'pretty_name': 'Test Package', 'sample_repo': '', 'category': 'testing', 'description': "Let's test this!", 'imagestream_files': [{'filename': 'test-centos.json', 'latest': '2-el9', 'distros': [{'name': 'CentOS Stream 8', 'app_versions': [2, 3, 1]}, {'name': 'CentOS Stream 9', 'app_versions': [2]}]}]}
+    result = {"name": "test_pkg", "pretty_name": "Test Package", "sample_repo": "", "category": "testing", "description": "Let's test this!", "imagestream_files": [{"filename": "test-centos.json", "latest": "2-el9", "distros": [{"name": "CentOS Stream 8", "app_versions": [2, 3, 1]}, {"name": "CentOS Stream 9", "app_versions": [2]}]}]}
     assert loader.json_data == result

--- a/ocp-stream-generator/tests/test_yaml_loader.py
+++ b/ocp-stream-generator/tests/test_yaml_loader.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+
+import pytest
+import sys
+
+from stream_generator import YamlLoader
+
+def test_load_yaml():
+    loader = YamlLoader("tests/data/minimal.yml")
+    result = {'name': 'test_pkg', 'pretty_name': 'Test Package', 'sample_repo': '', 'category': 'testing', 'description': "Let's test this!", 'imagestream_files': [{'filename': 'test-centos.json', 'latest': '2-el9', 'distros': [{'name': 'CentOS Stream 8', 'app_versions': [2, 3, 1]}, {'name': 'CentOS Stream 9', 'app_versions': [2]}]}]}
+    assert loader.json_data == result

--- a/ocp-stream-generator/tests/test_yaml_loader.py
+++ b/ocp-stream-generator/tests/test_yaml_loader.py
@@ -8,4 +8,4 @@ from data.data_yaml_loader import load_yaml_result
 
 def test_load_yaml():
     loader = YamlLoader("tests/data/minimal.yml")
-    assert loader.json_data == load_yaml_result
+    assert loader.data == load_yaml_result

--- a/ocp-stream-generator/tox.ini
+++ b/ocp-stream-generator/tox.ini
@@ -1,0 +1,5 @@
+[testenv]
+commands = python3 -m pytest --color=yes -v
+deps =
+    pytest
+    PyYAML


### PR DESCRIPTION
This is still a Work in Progress. Support for latest imagestreams is not yet implemented. The config for this script is to be given as its first argument and should have following format:

```
$ cat imagestreams.yaml
---
- name: postgresql
  pretty_name: PostgreSQL
  category: database
  sample_repo: ""
  description: > 
    Provides a PostgreSQL APP_VERSION database on DISTRO_NAME.
    For more information about using this database image, including OpenShift considerations,
    see https://github.com/sclorg/postgresql-container/blob/master/README.md.
  imagestream_files:
  - filename: postgresql-rhel.json
    latest: "15-el8"
    distros:
      - name: RHEL 8
        app_versions: [12, 13, 15]

      - name: RHEL 7
        app_versions: [10]
```  
  This shall be documented before a merge.

