### PR TITLE
Disable testing mysql-container.

### DIFF
--- a/daily_tests/daily_scl_tests.sh
+++ b/daily_tests/daily_scl_tests.sh
@@ -18,7 +18,6 @@ httpd-container
 redis-container
 mariadb-container
 postgresql-container
-mysql-container
 "
 
 [[ -z "$1" ]] && { echo "You have to specify target to build SCL images. centos7, rhel7 or fedora" && exit 1 ; }


### PR DESCRIPTION
  #=> sourcing 50-passwd-change.sh ...
  #---> 12:23:07     Setting passwords ...
  #---> 12:26:30     Shutting down MySQL ...
  #mysqladmin: reload failed; error: 'Lost connection to MySQL server during query'
  #/usr/share/container-scripts/mysql/common.sh: line 100:    74 Killed                  ${MYSQL_PREFIX}/libexec/mysqld --defaults-file=$MYSQL_DEFAULTS_FILE --skip-networking --socket=$MYSQL_LOCAL_SOCKET "$@"
  #Test for image 'rhel8/mysql-80:1' FAILED (exit code: 1)
  #    Created container 65a87f95db0c6e2fc513543e2daff9acfe8916b2bc4c32d8bcee2301309bd82e
  #  Testing MySQL connection to 10.88.11.184...

<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
