### PR TITLE
is generator: add possibility to generate custom tags, and to specify target dir

### DIFF
--- a/ocp-stream-generator/ocp-stream-generator/stream_generator.py
+++ b/ocp-stream-generator/ocp-stream-generator/stream_generator.py
@@ -215,10 +215,15 @@ class JsonBuilder:
         return json.dumps(_json, indent=2)
 
 def main():
-    if len(sys.argv) != 2:
-        print("please provide YAML conf file as first parameter of this script")
+    path_to_isfiles="."
+    if len(sys.argv) >= 2:
+        yaml_loader = YamlLoader(sys.argv[1])
+        if len(sys.argv) == 3:
+            path_to_isfiles = sys.argv[2]
+    else:
+        print("usage: stream_generator [YAML CONFIG] [OUTPUT DIR]")
+        print("OUTPUT DIR is \".\", if not specified otherwise")
         return 5
-    yaml_loader = YamlLoader(sys.argv[1])
     builder = JsonBuilder()
 
     isf_header = yaml_loader.data
@@ -227,7 +232,9 @@ def main():
         isf_data = ImagestreamFile(isf, isf_header)
         if not isf_data.is_correct:
             return 5
-        with open(isf_data.filename, "w") as json_file:
+        filename = f"{path_to_isfiles}/{isf_data.filename}"
+        print(f"generating {filename}")
+        with open(filename, "w") as json_file:
             json_file.write(builder.generate_json(isf_data)+ "\n")
 
 if __name__ == "__main__":

--- a/ocp-stream-generator/tests/data/data_json_builder.py
+++ b/ocp-stream-generator/tests/data/data_json_builder.py
@@ -2,6 +2,8 @@ add_tag_result = {"spec": {"tags": [{"name": "1-el8", "annotations": {"openshift
 
 add_tag_latest_result = {"spec": {"tags": [{"name": "latest", "annotations": {"openshift.io/display-name": "Test 1 (Latest)", "openshift.io/provider-display-name": "Red Hat, Inc.", "description": "test description\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version available on OpenShift, including major version updates.\n", "iconClass": "icon-test", "tags": "test,test", "version": "1"}, "from": {"kind": "ImageStreamTag", "name": "1-el8"}, "referencePolicy": {"type": "Local"}}]}}
 
+add_tag_custom_result = {'spec': {'tags': [{'name': 'some custom name', 'annotations': {'openshift.io/display-name': 'Test 13 (RHEL 8)', 'openshift.io/provider-display-name': 'Red Hat, Inc.', 'description': 'test description', 'iconClass': 'icon-test', 'tags': 'test,test', 'version': '13'}, 'from': {'kind': 'DockerImage', 'name': 'registry.redhat.io/rhel8/test-13:latest'}, 'referencePolicy': {'type': 'Local'}}]}}
+
 create_annotation_result = {"openshift.io/display-name": "Test 1 (RHEL 8)", "openshift.io/provider-display-name": "Red Hat, Inc.", "description": "test description", "iconClass": "icon-test", "tags": "test,test", "version": "1"}
 
 create_annotation_latest_result = {"openshift.io/display-name": "Test 1 (Latest)", "openshift.io/provider-display-name": "Red Hat, Inc.", "description": "test description\n\nWARNING: By selecting this tag, your application will automatically update to use the latest version available on OpenShift, including major version updates.\n", "iconClass": "icon-test", "tags": "test,test", "version": "1"}

--- a/ocp-stream-generator/tests/test_imagestream_file.py
+++ b/ocp-stream-generator/tests/test_imagestream_file.py
@@ -11,8 +11,23 @@ def test_create_isf():
     isf = {"filename": "test-centos.json", "latest": "2-el9", "distros": [{"name": "CentOS Stream 8", "app_versions": [2, 3, 1]}, {"name": "CentOS Stream 9", "app_versions": [2]}]}
     isf_header = {"name": "test_pkg", "pretty_name": "Test Package", "sample_repo": "", "category": "testing", "description": "Let's test this!"}
     isf_data = ImagestreamFile(isf, isf_header)
-    assert isf_data.latest_tag.latest == "2-el9"
+    assert isf_data.latest_tag.stream_name == "latest"
+    assert isf_data.latest_tag.image == "2-el9"
     assert isf_data.app_pretty_name == "Test Package"
     assert isf_data.app_name == "test_pkg"
     assert isf_data.latest_tag.distro_name == "CentOS Stream 9"
     assert isf_data.tags[0].description == "Let's test this!"
+
+def test_create_isf_custom_tags():
+    isf = {"filename": "test-centos.json", "custom_tags": [{"name": "my custom tag", "app_version": "11", "distro": "UBI 7"}], "latest": "2-el9", "distros": [{"name": "CentOS Stream 8", "app_versions": [2, 3, 1]}, {"name": "CentOS Stream 9", "app_versions": [2]}]}
+    isf_header = {"name": "test_pkg", "pretty_name": "Test Package", "sample_repo": "", "category": "testing", "description": "Let's test this!"}
+    isf_data = ImagestreamFile(isf, isf_header)
+    print(isf_data.tags)
+    assert isf_data.latest_tag.stream_name == "latest"
+    assert isf_data.latest_tag.image == "2-el9"
+    assert isf_data.app_pretty_name == "Test Package"
+    assert isf_data.app_name == "test_pkg"
+    assert isf_data.latest_tag.distro_name == "CentOS Stream 9"
+    assert isf_data.tags[0].description == "Let's test this!"
+    assert isf_data.custom_tags[0].stream_name == "my custom tag"
+    assert isf_data.custom_tags[0].distro_name == "UBI 7"

--- a/ocp-stream-generator/tests/test_json_builder.py
+++ b/ocp-stream-generator/tests/test_json_builder.py
@@ -5,9 +5,12 @@ import sys
 import re
 from stream_generator import JsonBuilder
 from stream_generator import Tag
+from stream_generator import LatestTag
+from stream_generator import CustomTag
 from stream_generator import ImagestreamFile
 from data.data_json_builder import add_tag_result
 from data.data_json_builder import add_tag_latest_result
+from data.data_json_builder import add_tag_custom_result
 from data.data_json_builder import create_annotation_result
 from data.data_json_builder import create_annotation_latest_result
 from data.data_json_builder import create_header_result
@@ -19,19 +22,23 @@ header = {"name": "test", "pretty_name": "Test", "sample_repo": "", "category": 
 
 
 def test_add_tag():
-    tag = Tag(header, "RHEL 8", "private", version=1)
+    tag = Tag(header, "RHEL 8", "private", 1)
     assert builder.add_tag({"spec": { "tags": []}}, tag)  ==  add_tag_result
 
 def test_add_latest_tag():
-    tag_latest = Tag(header, "RHEL8", "private", latest="1-el8")
+    tag_latest = LatestTag(header, "RHEL 8", "private", "1-el8")
     assert builder.add_tag({"spec": { "tags": []}}, tag_latest)  ==  add_tag_latest_result
 
+def test_add_custom_tag():
+    tag_custom = CustomTag(header, "private", {"distro": "RHEL 8", "name": "some custom name", "app_version": "13"})
+    assert builder.add_tag({"spec": { "tags": []}}, tag_custom)  ==  add_tag_custom_result
+
 def test_create_annotation():
-    tag = Tag(header, "RHEL 8", "private", version=1)
+    tag = Tag(header, "RHEL 8", "private", 1)
     assert builder.create_annotation(tag) == create_annotation_result
 
 def test_create_annotation_latest():
-    latest_tag = Tag(header, "RHEL 8", "private", latest="1-el8")
+    latest_tag = LatestTag(header, "RHEL 8", "private", "1-el8")
     assert builder.create_annotation(latest_tag) == create_annotation_latest_result
 
 def test_create_header():


### PR DESCRIPTION
Custom tags are needed for backwards compatibility - some of our imagestream tags are already shipped, but are in non-strandard format. We need to make sure we provide these tags in full lifecycle of the image. Until now stream generator was able to generate only standard tags in format <version>-<distro> (e.g., 16-el8). With adding custom tags feature we can now specify full tag name any format we like. 
See, e.g., in here: https://github.com/sclorg/s2i-nodejs-container/pull/427.
