### PR TITLE
Revert "Add mysql-container to daily builds. It was removed for some reason."

### DIFF
--- a/daily_tests/daily_scl_tests.sh
+++ b/daily_tests/daily_scl_tests.sh
@@ -20,10 +20,9 @@ varnish-container
 nginx-container
 httpd-container
 redis-container
-valkey-container
 mariadb-container
 postgresql-container
-mysql-container
+valkey-container
 "
 
 [[ -z "$1" ]] && { echo "You have to specify target to build SCL images. rhel9, rhel8, or fedora" && exit 1 ; }


### PR DESCRIPTION
Reverts sclorg/ci-scripts#168

The mysql-container did not finish at all and it blocks our CI systems. For some reason, in case it is in cronjob, it expects output and timeouts.